### PR TITLE
Expanding configuration files

### DIFF
--- a/src/outlook_calendar_sync/gcal.py
+++ b/src/outlook_calendar_sync/gcal.py
@@ -20,8 +20,10 @@ def get_gcal_api():
     # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if Path("./token.json").exists():
-        creds = Credentials.from_authorized_user_file("token.json", SCOPES)
+    config_dir = Path.home() / ".config" / "outlook-calendar-sync"
+    config_file = config_dir / "token.json"
+    if config_file.exists():
+        creds = Credentials.from_authorized_user_file(config_file, SCOPES)
 
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
@@ -31,7 +33,7 @@ def get_gcal_api():
             flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
             creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
-        with open("token.json", "w") as token:
+        with open(config_dir / "token.json", "w") as token:
             token.write(creds.to_json())
 
     return build("calendar", "v3", credentials=creds)

--- a/src/outlook_calendar_sync/utils.py
+++ b/src/outlook_calendar_sync/utils.py
@@ -6,7 +6,7 @@ from os import PathLike
 from pathlib import Path
 from typing import TypeVar
 
-default_config_path = Path.home() / ".outlook-parser-config.ini"
+default_config_path = Path.home() / ".config" / "outlook-calendar-sync" / ".config.ini"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Moved the configuration file into a directory `HOME/.config/outlook-calendar-sync`. This implementation needs to be expanded by checking for the platform in the `config.py` file. This also allows for another user to generate their own google application files and run this tool as a standalone.

The main reason is to allow running `outlook-calendar-sync` command from any directory, rather than it being dependant on the `token.json` or `credentials.json` files.
